### PR TITLE
Updated fabric version string to support 1.18.1

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -38,7 +38,7 @@
   "depends": {
     "fabricloader": ">=0.12.6",
     "fabric": "*",
-    "minecraft": "1.18",
+    "minecraft": "1.18.1",
     "java": ">=17"
   },
   "suggests": {


### PR DESCRIPTION
I know this is very small, but should save a headache for anyone trying to install the mod on 1.18.1 through Fabric. 

As it stands currently, the Forge version already works on 1.18.1. Though, if you try to load the mod through Fabric, it complains that it requires _specifically_ 1.18 (.0 original release), and simply changing the version string in the mod's json file allows it to work on 1.18.1.